### PR TITLE
updating gdm.transform for v1.6.0-5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gdm
 Title: Generalized Dissimilarity Modeling
-Version: 1.6.0-4
-Date: 2024-12-02
+Version: 1.6.0-5
+Date: 2024-12-04
 Authors@R: 
     c(person("Matt", "Fitzpatrick", email="mfitzpatrick@umces.edu", 
     role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 <!-- See http://style.tidyverse.org/news.html for advice on writing news -->
 
+# gdm 1.6.0-5
+* Updated `gdm.transform` to handle NAs in large rasters and prevent write error (issue #52).
+* Added the `colorRamps::` to the README file examples (issue #50).
+
 # gdm 1.6.0-4
 * Incremental update to package testing scripts.
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -296,7 +296,7 @@ library(colorRamps)
 
 ```{r predictTimeGDM, warning=FALSE, message=FALSE, fig.height=4, fig.width=4, fig.cap="Predicted magnitude of biological change through time"}
 timePred <- predict(gdm.rast, swBioclims, time=TRUE, predRasts=futRasts)
-terra::plot(timePred, col=rgb.tables(1000))
+terra::plot(timePred, col=colorRamps::rgb.tables(1000))
 ```
 
 ##  Transforming spatial predictor layers using a fitted GDM
@@ -314,7 +314,7 @@ We then use the `gdm.transform` function to rescale the rasters.
 
 ```{r transformGDM, warning=FALSE, message=FALSE}
 transRasts <- gdm.transform(model=gdmRastMod, data=swBioclims)
-terra::plot(transRasts, col=rgb.tables(1000))
+terra::plot(transRasts, col=colorRamps::rgb.tables(1000))
 ```
 
 ## Visualizing multi-dimensional biological patterns

--- a/inst/tinytest/test_gdm.R
+++ b/inst/tinytest/test_gdm.R
@@ -37,10 +37,10 @@ expect_silent({
 ## test predict function ---------------------------------------------------
 # futureRast <- envRast
 # futureRast[[3]] <- futureRast[[3]] * 0.75
-# 
+#
 # # check prediction is done silently i.e. no errors/warnings
 # expect_silent({
-# 
+#
 #  pred_raster <- gdm:::predict.gdm(
 #     object = gdmRastMod,
 #     data = envRast,
@@ -48,21 +48,21 @@ expect_silent({
 #     predRasts = futureRast,
 #     filename = tempfile(fileext = ".tif")
 #   )
-# 
+#
 # })
-# 
+#
 # # read the prediction created by gdm version 1.5.x
 # pred_v1.5 <- terra::rast(
 #   system.file("./extdata/test_data/pred_3_75.tif", package="gdm")
 # )
-# 
+#
 # # round as file compression might lose some precision
 # diff <- round(terra::global(pred_raster - pred_v1.5, "mean", na.rm = TRUE)[1,1], 5)
-# 
+#
 # expect_true(
 #   diff == 0
 # )
-# 
+#
 
 # test transform function -------------------------------------------------
 
@@ -87,6 +87,6 @@ diff <- round(terra::global(trans_raster - trans_v1.5, "mean", na.rm = TRUE)[, 1
 
 # expect all difference be zero
 expect_true(
-  all(diff == 0)
+  all(diff < 0.05)
 )
 

--- a/man/formatsitepair.Rd
+++ b/man/formatsitepair.Rd
@@ -207,8 +207,8 @@ exact same coordinates.
 ## tabular data
 # start with the southwest data table
  head(southwest)
- sppData <- southwest[c(1,2,13,14)]
- envTab <- southwest[c(2:ncol(southwest))]
+ sppData <- southwest[, c(1,2,13,14)]
+ envTab <- southwest[, c(2:ncol(southwest))]
 
 #########table type 1
 ## site-species table without coordinates

--- a/man/gdm.Rd
+++ b/man/gdm.Rd
@@ -95,8 +95,8 @@ s1.Rain, s1.Bedrock, s2.Temp, s2.Rain, s2.Bedrock
  ##fit table environmental data
  # format site-pair table using the southwest data table
  head(southwest)
- sppData <- southwest[c(1,2,13,14)]
- envTab <- southwest[c(2:ncol(southwest))]
+ sppData <- southwest[, c(1,2,13,14)]
+ envTab <- southwest[, c(2:ncol(southwest))]
 
  sitePairTab <- formatsitepair(sppData, 2, XColumn="Long", YColumn="Lat", sppColumn="species",
                                siteColumn="site", predData=envTab)

--- a/man/gdm.partition.deviance.Rd
+++ b/man/gdm.partition.deviance.Rd
@@ -27,8 +27,8 @@ user specified components - most typically environment versus space.
 }
 \examples{
 # set up site-pair table using the southwest data set
-sppData <- southwest[c(1,2,13,14)]
-envTab <- southwest[c(2:ncol(southwest))]
+sppData <- southwest[, c(1,2,13,14)]
+envTab <- southwest[, c(2:ncol(southwest))]
 sitePairTab <- formatsitepair(sppData, 2, XColumn="Long", YColumn="Lat",
 sppColumn="species", siteColumn="site", predData=envTab)
 

--- a/man/gdm.varImp.Rd
+++ b/man/gdm.varImp.Rd
@@ -110,8 +110,8 @@ by the user and the pValue argument.
 \examples{
 ##fit table environmental data
 ##set up site-pair table using the southwest data set
-sppData <- southwest[c(1,2,13,14)]
-envTab <- southwest[c(2:ncol(southwest))]
+sppData <- southwest[, c(1,2,13,14)]
+envTab <- southwest[, c(2:ncol(southwest))]
 sitePairTab <- formatsitepair(sppData, 2, XColumn="Long", YColumn="Lat",
 sppColumn="species", siteColumn="site", predData=envTab)
 

--- a/man/plot.gdm.Rd
+++ b/man/plot.gdm.Rd
@@ -49,8 +49,8 @@ dissimilarity model created using the \code{\link[gdm]{gdm}} function.
 }
 \examples{
 ##set up site-pair table using the southwest data set
-sppData <- southwest[c(1,2,13,14)]
-envTab <- southwest[c(2:ncol(southwest))]
+sppData <- southwest[, c(1,2,13,14)]
+envTab <- southwest[, c(2:ncol(southwest))]
 sitePairTab <- formatsitepair(sppData, 2, XColumn="Long", YColumn="Lat",
                               sppColumn="species", siteColumn="site",
                               predData=envTab)

--- a/man/plotUncertainty.Rd
+++ b/man/plotUncertainty.Rd
@@ -61,8 +61,8 @@ x and y values containing the lower bound, full model, and upper bound.
 }
 \examples{
 ##set up site-pair table using the southwest data set
-sppData <- southwest[c(1,2,13,14)]
-envTab <- southwest[c(2:ncol(southwest))]
+sppData <- southwest[, c(1,2,13,14)]
+envTab <- southwest[, c(2:ncol(southwest))]
 sitePairTab <- formatsitepair(sppData, 2, XColumn="Long", YColumn="Lat",
                               sppColumn="species", siteColumn="site", predData=envTab)
 

--- a/man/subsample.sitepair.Rd
+++ b/man/subsample.sitepair.Rd
@@ -34,8 +34,8 @@ in the site-pair table.
 }
 \examples{
 ##set up site-pair table using the southwest data set
-sppData <- southwest[c(1,2,13,14)]
-envTab <- southwest[c(2:ncol(southwest))]
+sppData <- southwest[, c(1,2,13,14)]
+envTab <- southwest[, c(2:ncol(southwest))]
 sitePairTab <- formatsitepair(sppData, 2, XColumn="Long", YColumn="Lat", sppColumn="species",
                               siteColumn="site", predData=envTab)
 


### PR DESCRIPTION
Hi @fitzLab-AL 

I’ve updated `gdm.transform` to address issue #52 created by my colleague (and also #50).

I also added the min/max of the xy coordinates directly into the transform function so that processing large rasters in chunks now produces the correct output. To achieve this, I pass the raster extent, which avoids any extra calculations. This approach is slightly different from earlier versions, where the min/max of non-NA cells were used (becasue the raster layers where first transformed to a data.frame). The difference should be negligible, and it eliminates the need to extract all xy coordinates and compute their min/max (very costly for large rasters). I don’t think this is a big deal, but just sharing the update here! :)

Regards,
Roozbeh